### PR TITLE
API v11

### DIFF
--- a/embulk-input-twitter_ads_analytics.gemspec
+++ b/embulk-input-twitter_ads_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-twitter_ads_analytics"
-  spec.version = "0.3.0"
+  spec.version = "0.4.0"
   spec.authors = ["naotaka nakane"]
   spec.summary = "Twitter Ads Analytics input plugin for Embulk"
   spec.description = "Loads records from Twitter Ads Analytics."

--- a/lib/embulk/input/twitter_ads_analytics.rb
+++ b/lib/embulk/input/twitter_ads_analytics.rb
@@ -254,8 +254,8 @@ module Embulk
       def request_entities(access_token)
         retries = 0
         begin
-          url = "https://ads-api.twitter.com/10/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
-          url = "https://ads-api.twitter.com/10/accounts/#{@account_id}" if @entity == "ACCOUNT"
+          url = "https://ads-api.twitter.com/11/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
+          url = "https://ads-api.twitter.com/11/accounts/#{@account_id}" if @entity == "ACCOUNT"
           response = access_token.request(:get, url)
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
@@ -292,7 +292,7 @@ module Embulk
             placement: @placement,
             granularity: @granularity,
           }
-          response = access_token.request(:get, "https://ads-api.twitter.com/10/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
+          response = access_token.request(:get, "https://ads-api.twitter.com/11/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
             raise ERRORS["#{response.code}"]


### PR DESCRIPTION
Updated twitter ads api version to v11.

The following `report` confirms that there is no difference between v10 and v11.
- account
- campaign
- line_item

documents
https://twittercommunity.com/t/ads-api-version-11/168814