### PR TITLE
Add campaign_id in LINE_ITEM

### DIFF
--- a/embulk-input-twitter_ads_analytics.gemspec
+++ b/embulk-input-twitter_ads_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-twitter_ads_analytics"
-  spec.version = "0.4.0"
+  spec.version = "0.4.1"
   spec.authors = ["naotaka nakane"]
   spec.summary = "Twitter Ads Analytics input plugin for Embulk"
   spec.description = "Loads records from Twitter Ads Analytics."

--- a/lib/embulk/input/twitter_ads_analytics.rb
+++ b/lib/embulk/input/twitter_ads_analytics.rb
@@ -86,7 +86,7 @@ module Embulk
         columns += [
           {name: "line_item_id", type: "string"},
           {name: "line_item_name", type: "string"},
-          {name: "campaign_id_in_line_item", type: "string"},
+          {name: "campaign_id", type: "string"},
         ] if entity == "LINE_ITEM"
         columns += [
           {name: "funding_instrument_id", type: "string"},
@@ -215,7 +215,7 @@ module Embulk
             response.each do |row|
               row["start_date"] = chunked_time[:start_date]
               row["end_date"] = chunked_time[:end_date]
-              row["campaign_id_in_line_item"] = line_item_campaign_id[row["id"]] if @entity == "LINE_ITEM"
+              row["campaign_id"] = line_item_campaign_id[row["id"]] if @entity == "LINE_ITEM"
             end
             stats += response
           end
@@ -225,10 +225,10 @@ module Embulk
           (Date.parse(item["start_date"])..Date.parse(item["end_date"])).each_with_index do |date, i|
             page = []
             @columns.each do |column|
-              if ["account_id", "campaign_id", "line_item_id", "funding_instrument_id"].include?(column["name"])
+              if @entity == "LINE_ITEM" && column["name"] == "campaign_id"
+                page << item["campaign_id"]
+              elsif ["account_id", "campaign_id", "line_item_id", "funding_instrument_id"].include?(column["name"])
                 page << item["id"]
-              elsif column["name"] == "campaign_id_in_line_item"
-                page << item["campaign_id_in_line_item"]
               elsif column["name"] == "date"
                 page << Time.zone.parse(date.to_s)
               elsif ["account_name", "campaign_name", "line_item_name"].include?(column["name"])


### PR DESCRIPTION
# Overview
* campaign_id is contained to the transfer contents when enntity is LINE_ITEM
* https://github.com/primenumber-dev/n-transfer-ui/issues/10468