### PR TITLE
Update api v12

### DIFF
--- a/embulk-input-twitter_ads_analytics.gemspec
+++ b/embulk-input-twitter_ads_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-twitter_ads_analytics"
-  spec.version = "0.4.1"
+  spec.version = "0.5.0"
   spec.authors = ["naotaka nakane"]
   spec.summary = "Twitter Ads Analytics input plugin for Embulk"
   spec.description = "Loads records from Twitter Ads Analytics."

--- a/lib/embulk/input/twitter_ads_analytics.rb
+++ b/lib/embulk/input/twitter_ads_analytics.rb
@@ -12,6 +12,8 @@ module Embulk
       NUMBER_OF_RETRIES = 5
       MAX_SLEEP_SEC_NUMBER = 1200
 
+      ADS_API_VERSION = 12
+
       # Error codes and responses
       # @see https://developer.twitter.com/en/docs/twitter-ads-api/response-codes
       # Client Errors (4XX)
@@ -262,8 +264,8 @@ module Embulk
       def request_entities(access_token)
         retries = 0
         begin
-          url = "https://ads-api.twitter.com/12/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
-          url = "https://ads-api.twitter.com/12/accounts/#{@account_id}" if @entity == "ACCOUNT"
+          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
+          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}" if @entity == "ACCOUNT"
           response = access_token.request(:get, url)
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
@@ -300,7 +302,7 @@ module Embulk
             placement: @placement,
             granularity: @granularity,
           }
-          response = access_token.request(:get, "https://ads-api.twitter.com/12/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
+          response = access_token.request(:get, "https://ads-api.twitter.com/#{ADS_API_VERSION}/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
             raise ERRORS["#{response.code}"]

--- a/lib/embulk/input/twitter_ads_analytics.rb
+++ b/lib/embulk/input/twitter_ads_analytics.rb
@@ -262,8 +262,8 @@ module Embulk
       def request_entities(access_token)
         retries = 0
         begin
-          url = "https://ads-api.twitter.com/11/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
-          url = "https://ads-api.twitter.com/11/accounts/#{@account_id}" if @entity == "ACCOUNT"
+          url = "https://ads-api.twitter.com/12/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
+          url = "https://ads-api.twitter.com/12/accounts/#{@account_id}" if @entity == "ACCOUNT"
           response = access_token.request(:get, url)
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
@@ -300,7 +300,7 @@ module Embulk
             placement: @placement,
             granularity: @granularity,
           }
-          response = access_token.request(:get, "https://ads-api.twitter.com/11/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
+          response = access_token.request(:get, "https://ads-api.twitter.com/12/stats/accounts/#{@account_id}?#{URI.encode_www_form(params)}")
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"
             raise ERRORS["#{response.code}"]


### PR DESCRIPTION
Updated twitter ads api version to v12.

I confirmed that following APIs are no difference between v11 and v12.
- accounts
- campaigns
- line_items
- promoted_tweets
- funding_instruments

Documents are [here](https://twittercommunity.com/t/ads-api-version-12/179094)
