### PR TITLE
Set count=1000 when retrieving entities

### DIFF
--- a/embulk-input-twitter_ads_analytics.gemspec
+++ b/embulk-input-twitter_ads_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-twitter_ads_analytics"
-  spec.version = "0.5.0"
+  spec.version = "0.5.1"
   spec.authors = ["naotaka nakane"]
   spec.summary = "Twitter Ads Analytics input plugin for Embulk"
   spec.description = "Loads records from Twitter Ads Analytics."

--- a/lib/embulk/input/twitter_ads_analytics.rb
+++ b/lib/embulk/input/twitter_ads_analytics.rb
@@ -264,8 +264,9 @@ module Embulk
       def request_entities(access_token)
         retries = 0
         begin
-          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}/#{entity_plural(@entity).downcase}"
-          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}" if @entity == "ACCOUNT"
+          query = {count: 1000}.to_query
+          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}/#{entity_plural(@entity).downcase}?#{query}"
+          url = "https://ads-api.twitter.com/#{ADS_API_VERSION}/accounts/#{@account_id}?#{query}" if @entity == "ACCOUNT"
           response = access_token.request(:get, url)
           if ERRORS["#{response.code}"].present?
             Embulk.logger.error "#{response.body}"


### PR DESCRIPTION
# changes
- Set `count=1000`
    - By default, only  retrieve 200 entities. Thus, entities missing if they are more than 201.
   
# refs
see `count` parameter.
- https://developer.twitter.com/ja/docs/twitter-ads-api/campaign-management/api-reference/campaigns
- https://developer.twitter.com/ja/docs/twitter-ads-api/campaign-management/api-reference/line-items
- https://developer.twitter.com/ja/docs/twitter-ads-api/campaign-management/api-reference/accounts
- https://developer.twitter.com/ja/docs/twitter-ads-api/campaign-management/api-reference/promoted-tweets
- https://developer.twitter.com/ja/docs/twitter-ads-api/campaign-management/api-reference/funding-instruments

