### PR TITLE
bump up version 0.6.1 --> 0.6.2

### DIFF
--- a/embulk-input-twitter_ads_analytics.gemspec
+++ b/embulk-input-twitter_ads_analytics.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "embulk-input-twitter_ads_analytics"
-  spec.version = "0.6.1"
+  spec.version = "0.6.2"
   spec.authors = ["naotaka nakane"]
   spec.summary = "Twitter Ads Analytics input plugin for Embulk"
   spec.description = "Loads records from Twitter Ads Analytics."


### PR DESCRIPTION
bump up version 0.6.1 --> 0.6.2

**pull-requests included in this version**
- https://github.com/trocco-io/embulk-input-twitter_ads_analytics/pull/20